### PR TITLE
Remove Widen-specific DSLs

### DIFF
--- a/.buildkite/pipeline.extra.gradle
+++ b/.buildkite/pipeline.extra.gradle
@@ -5,6 +5,20 @@ buildkite.pipeline('extra') {
 
     blockStep 'Wait a minute!'
 
+    commandStep {
+        plugin 'foobar', [
+            name: 'Baz',
+            list: [
+                [
+                    x: 1
+                ],
+                [
+                    x: 2
+                ]
+            ]
+        ]
+    }
+
     blockStep(':rocket: Release!') {
         prompt 'Fill out the details for this release'
         branches '*.*.*'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gradle Buildkite Plugin
+# Buildkite Gradle Plugin
 
 [![Build Status](https://badge.buildkite.com/9a1d9c36585e925d7b531e3f456a33de3bddda2a6db9ffee91.svg)](https://buildkite.com/widen/gradle-buildkite-plugin)
 
@@ -9,4 +9,4 @@ Provides a Gradle DSL for dynamically generating Buildkite pipelines.
 Please check out the [documentation] to learn what this plugin can do and how to use it.
 
 
-[documentation]: https://docs.yden.us/gradle-buildkite-plugin/
+[documentation]: https://docs.yden.us/buildkite-gradle-plugin/

--- a/build.gradle
+++ b/build.gradle
@@ -73,20 +73,24 @@ buildkite {
             }
         }
 
-        // Some step methods are just conveniences that generate a more complex step from simple configuration.
-        publishDocsStep {
-            appName = 'Gradle Buildkite Plugin'
+        commandStep {
+            label ':md: Publish docs'
+
+            // Custom plugins can also be used by name.
+            plugin 'Widen/docs-publisher#v1', {
+                title 'Buildkite Gradle Plugin'
+            }
         }
 
         waitStep()
 
-        gradleStep {
+        commandStep {
             label ':maven: Publish JARs'
-            task 'publish --continue'
+            command "./gradlew publish --continue \${GRADLE_SWITCHES}"
             branches '*.*.*'
-            // Gradle steps can set system properties.
-            systemProperty 'app.foo', true
-            // Note that many fields are optional.
+            dockerCompose {
+                run 'gradle'
+            }
         }
 
         // You can also set environment variables that apply to the whole pipeline.
@@ -97,6 +101,9 @@ buildkite {
 
     // You can also add additional pipelines with a name other than the default.
     pipeline 'secondary', {}
+
+    // The default agent queue for steps that do not specify one is "builder", but this can be changed here.
+    defaultAgentQueue 'builder'
 
     // You can also define pipelines in external script files inside your .buildkite directory matching the pattern 'buildkite*.gradle' and they will be
     // included automatically. This is true by default.

--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
@@ -1,5 +1,6 @@
 package com.widen.plugins.buildkite
 
+import groovy.json.JsonBuilder
 import groovy.json.JsonOutput
 
 import java.nio.file.Files
@@ -55,7 +56,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
      *
      * @param closure
      */
-    void commandStep(@DelegatesTo(CommandStep) Closure closure) {
+    void commandStep(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = CommandStep) Closure closure) {
         def step = new CommandStep()
         step.with(closure)
         steps << step.model
@@ -67,7 +68,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
     class CommandStep extends Step implements ConfigurableEnvironment {
         // Set defaults.
         {
-            agentQueue 'builder'
+            agentQueue pluginConfig.defaultAgentQueue
         }
 
         /**
@@ -142,7 +143,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
         /**
          * Retry this step automatically on failure.
          */
-        void automaticRetry(@DelegatesTo(AutomaticRetry) Closure closure) {
+        void automaticRetry(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = AutomaticRetry) Closure closure) {
             def config = new AutomaticRetry()
             config.with(closure)
             model.get('retry', [:]).automatic = config.model
@@ -201,9 +202,9 @@ class BuildkitePipeline implements ConfigurableEnvironment {
          * Add a Buildkite plugin to this step.
          *
          * @param name The plugin name.
-         * @param config An object that should be passed to the plugin as configuration.
+         * @param config An optional object that should be passed to the plugin as configuration.
          */
-        void plugin(String name, Object config) {
+        void plugin(String name, Object config = null) {
             plugin(name, pluginConfig.pluginVersions[name], config)
         }
 
@@ -211,10 +212,16 @@ class BuildkitePipeline implements ConfigurableEnvironment {
          * Add a Buildkite plugin to this step.
          *
          * @param name The plugin name.
-         * @param name The plugin version.
-         * @param config An object that should be passed to the plugin as configuration.
+         * @param version The plugin version.
+         * @param config An optional object that should be passed to the plugin as configuration, or a closure that constructs the configuration.
          */
-        void plugin(String name, String version, Object config) {
+        void plugin(String name, String version, Object config = null) {
+            if (config instanceof Closure) {
+                def builder = new JsonBuilder()
+                builder.call(config)
+                config = builder.content
+            }
+
             def key = version ? "$name#$version" : name
             model.get('plugins', []) << [
                 (key): config
@@ -224,7 +231,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
         /**
          * Add the <a href="https://github.com/buildkite-plugins/docker-buildkite-plugin">Docker plugin</a> to this step.
          */
-        void docker(@DelegatesTo(Docker) Closure closure) {
+        void docker(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Docker) Closure closure) {
             def config = new Docker()
             config.with(closure)
             plugin('docker', config.model)
@@ -310,7 +317,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
         /**
          * Add the <a href="https://github.com/buildkite-plugins/docker-compose-buildkite-plugin">Docker Compose plugin</a> to this step.
          */
-        void dockerCompose(@DelegatesTo(DockerCompose) Closure closure) {
+        void dockerCompose(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = DockerCompose) Closure closure) {
             def config = new DockerCompose()
 
             // Pre-populate some config files.
@@ -411,95 +418,11 @@ class BuildkitePipeline implements ConfigurableEnvironment {
     }
 
     /**
-     * Add a command step that executes a Gradle task.
-     */
-    void gradleStep(@DelegatesTo(GradleStep) Closure closure) {
-        def step = new GradleStep()
-
-        step.with {
-            with(closure)
-
-            def systemPropertyArgs = systemProperties.collect {
-                "-D$it.key=$it.value"
-            }
-
-            command "./gradlew $task ${systemPropertyArgs.join(' ')} \${GRADLE_SWITCHES}"
-
-            dockerCompose {
-                run 'gradle'
-            }
-        }
-
-        steps << step.model
-    }
-
-    /**
-     * Configuration for a Gradle command step.
-     */
-    class GradleStep extends CommandStep {
-        protected String task
-        protected String[] args = []
-        protected Map<String, Object> systemProperties = [:]
-
-        /**
-         * The name of the Gradle task to execute.
-         */
-        void task(String name) {
-            this.task = name
-        }
-
-        /**
-         * Arguments to pass to Gradle.
-         */
-        void args(String... args) {
-            this.args = args
-        }
-
-        /**
-         * Set a Java system property for the Gradle task.
-         */
-        void systemProperty(String name, Object value) {
-            systemProperties[name] = value
-        }
-    }
-
-    /**
-     * Add a command step runs the <a href="https://docs.yden.us/docs-publisher/">Docs Publisher</a>.
-     */
-    void publishDocsStep(@DelegatesTo(PublishDocsStep) Closure closure) {
-        def step = new PublishDocsStep()
-        step.with(closure)
-
-        Objects.requireNonNull(step.appName, 'appName')
-
-        commandStep {
-            model.putAll(step.model)
-
-            command 'publish-docs'
-            docker {
-                image 'quay.io/widen/docs-publisher'
-                alwaysPull()
-                environment 'APP_NAME', step.appName
-                environment 'BUILDKITE_BRANCH'
-                environment 'BUILDKITE_REPO'
-            }
-        }
-    }
-
-    class PublishDocsStep extends Step {
-        String appName
-
-        {
-            label ':md: Publish Docs'
-        }
-    }
-
-    /**
      * Add a <a href="https://buildkite.com/docs/pipelines/block-step">block step</a> to the pipeline.
      *
      * @param closure
      */
-    void blockStep(String label, @DelegatesTo(BlockStep) Closure closure = null) {
+    void blockStep(String label, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = BlockStep) Closure closure = null) {
         def step = new BlockStep()
         step.label(label)
         if (closure) {
@@ -531,7 +454,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
          * @param key The meta-data key that stores the field's input (e.g. via the buildkite-agent meta-data command) The key may only contain alphanumeric
          * characters, slashes or dashes.
          */
-        void textField(String label, String key, @DelegatesTo(TextField) Closure closure = null) {
+        void textField(String label, String key, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = TextField) Closure closure = null) {
             addField(new TextField(label, key), closure)
         }
 
@@ -549,7 +472,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
          * @param key The meta-data key that stores the field's input (e.g. via the buildkite-agent meta-data command) The key may only contain alphanumeric
          * characters, slashes or dashes.
          */
-        void selectField(String label, String key, @DelegatesTo(SelectField) Closure closure = null) {
+        void selectField(String label, String key, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = SelectField) Closure closure = null) {
             addField(new SelectField(label, key), closure)
         }
 
@@ -627,7 +550,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
      * @param trigger The slug of the pipeline to create a build. The pipeline slug must be lowercase.
      * @param closure
      */
-    void triggerStep(String trigger, @DelegatesTo(TriggerStep) Closure closure = null) {
+    void triggerStep(String trigger, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = TriggerStep) Closure closure = null) {
         def step = new TriggerStep(trigger)
         if (closure) {
             step.with(closure)
@@ -655,7 +578,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
         /**
          * Configure optional attributes for the triggered build.
          */
-        void build(@DelegatesTo(Build) Closure closure) {
+        void build(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = Build) Closure closure) {
             def build = new Build()
             build.with(closure)
         }
@@ -685,7 +608,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
             /**
              * Set meta-data for the build.
              */
-            void metadata(@DelegatesTo(Map) Closure closure) {
+            void metadata(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = Map) Closure closure) {
                 def map = [:]
                 closure = (Closure) closure.clone()
                 closure.delegate = map

--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePlugin.groovy
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePlugin.groovy
@@ -43,10 +43,13 @@ class BuildkitePlugin implements Plugin<Project> {
     }
 
     static class Config {
+        String defaultAgentQueue = 'builder'
+
         final Map<String, String> pluginVersions = [
             docker: 'v3.2.0',
             'docker-compose': 'v3.0.3',
         ]
+
         File rootDir
     }
 
@@ -60,6 +63,13 @@ class BuildkitePlugin implements Plugin<Project> {
         boolean includeScripts = true
 
         /**
+         * Set the default agent queue name to use for steps that do not specify one.
+         */
+        void defaultAgentQueue(String queueName) {
+            config.defaultAgentQueue = queueName
+        }
+
+        /**
          * Specify the version of a Buildkite plugin that should be used inside pipelines if no version is specified.
          */
         void pluginVersion(String name, String version) {
@@ -69,14 +79,14 @@ class BuildkitePlugin implements Plugin<Project> {
         /**
          * Defines the default pipeline.
          */
-        void pipeline(@DelegatesTo(BuildkitePipeline) Closure closure) {
+        void pipeline(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = BuildkitePipeline) Closure closure) {
             pipeline('default', closure)
         }
 
         /**
          * Defines a named pipeline.
          */
-        void pipeline(String name, @DelegatesTo(BuildkitePipeline) Closure closure) {
+        void pipeline(String name, @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = BuildkitePipeline) Closure closure) {
             pipelines[name] = {
                 def pipeline = new BuildkitePipeline(config)
                 pipeline.with(closure)


### PR DESCRIPTION
The Gradle and docs publisher DSLs are not applicable outside Widen, and should be implemented as Buildkite plugins instead. Rather, improve the DSL for plugin options to make using Buildkite plugins more natural.

Also fix the name of the project, which technically should be _Buildkite Gradle plugin_, as opposed to a Buildkite plugin for Gradle.