### PR TITLE
Add 'key' attribute to CommandStep

### DIFF
--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
@@ -201,6 +201,13 @@ class BuildkitePipeline implements ConfigurableEnvironment {
         }
 
         /**
+         * A unique string to identify the step.
+         */
+        void key(String key) {
+            model.key = key
+        }
+
+        /**
          * Add a Buildkite plugin to this step.
          *
          * @param name The plugin name or URL and version.

--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/idea/pipeline.gdsl
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/idea/pipeline.gdsl
@@ -62,6 +62,7 @@ contributor([ctx, closureCtx]) {
             The amount of time a job created from this step is allowed to run. If the job does not finish within this
             limit, it will be automatically cancelled and the build will fail.
         '''
+        method name: 'key', params: [key: String], doc: 'A unique string to identify the step.'
         method name: 'plugin', params: [name: String], doc: 'Add a Buildkite plugin to this step.'
         method name: 'plugin', params: [name: String, body: Object], doc: 'Add a Buildkite plugin to this step.'
         method name: 'docker', params: [body: Closure], doc: 'Add the Docker plugin to this step.'


### PR DESCRIPTION
**What the change is**
Adding the `key` attribute to `CommandStep`.

**Why the change is useful**
Adding a unique identifier to a command step is useful for a number of reasons (such as GraphQL querying) and we use it in many of our pipelines. 
We use this plugin as a global template and services that use that template can't currently set the `key` attribute.

**Additional comments**
[Buildkite CommandStep documentation](https://buildkite.com/docs/pipelines/command-step)
If there's anything else needed, please just let me know!