### PR TITLE
Adds extra configuration options & updates plugin versions

### DIFF
--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkiteExtension.groovy
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkiteExtension.groovy
@@ -12,8 +12,8 @@ class BuildkiteExtension {
 
     @PackageScope
     final Map<String, String> pluginVersions = [
-        docker: 'v3.2.0',
-        'docker-compose': 'v3.0.3',
+        docker: 'v5.9.0',
+        'docker-compose': 'v4.15.0',
     ]
 
     /**

--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
@@ -287,6 +287,32 @@ class BuildkitePipeline implements ConfigurableEnvironment {
             }
 
             /**
+             * Automatically mount the `buildkite-agent` binary and associated
+             * environment variables from the host agent machine into the container.
+             */
+            void mountBuildkiteAgent() {
+                model['mount-buildkite-agent'] = true
+            }
+
+            /**
+             * Activate the interpolation of variables in the elements of the volumes
+             * configuration array. Environment variable interpolation rules apply here.
+             * `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` is
+             * at run time. All things being equal, you likely want `$$VARIABLE_NAME`.
+             */
+            void expandVolumeVars() {
+                model['expand-volume-vars'] = true
+            }
+
+            /**
+             * Enables debug mode, which outputs the full Docker commands that will be
+             * run on the agent machine.
+             */
+            void debug() {
+                model.debug = true
+            }
+
+            /**
              * Add a volume mount to pass to the container.
              */
             void volume(String source, String target) {
@@ -398,6 +424,33 @@ class BuildkitePipeline implements ConfigurableEnvironment {
              */
             void environment(String name, Object value) {
                 model.get('env', []) << "$name=$value"
+            }
+
+
+
+            /**
+             * Automatically propagate all pipeline environment variables into the container.
+             */
+            void propagateEnvironment() {
+                model['propagate-environment'] = true
+            }
+
+            /**
+             * Automatically mount the `buildkite-agent` binary and associated
+             * environment variables from the host agent machine into the container.
+             */
+            void mountBuildkiteAgent() {
+                model['mount-buildkite-agent'] = true
+            }
+
+            /**
+             * Activate the interpolation of variables in the elements of the volumes
+             * configuration array. Environment variable interpolation rules apply here.
+             * `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` is
+             * at run time. All things being equal, you likely want `$$VARIABLE_NAME`.
+             */
+            void expandVolumeVars() {
+                model['expand-volume-vars'] = true
             }
 
             /**

--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/idea/pipeline.gdsl
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/idea/pipeline.gdsl
@@ -97,6 +97,20 @@ contributor([ctx, closureCtx]) {
             '''
             method name: 'entrypoint', params: [entrypoint: String], doc: 'Override the Docker container entrypoint.'
             method name: 'shell', params: [args: 'java.lang.String[]'], doc: 'Set the shell to use for the command.'
+            method name: 'mountBuildkiteAgent', doc: '''
+                Automatically mount the `buildkite-agent` binary and associated environment 
+                variables from the host agent machine into the container.
+            '''
+            method name: 'expandVolumeVars', doc: '''
+                Activate the interpolation of variables in the elements of the volumes
+                configuration array. Environment variable interpolation rules apply here.
+                `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` is
+                at run time. All things being equal, you likely want `$$VARIABLE_NAME`.
+            '''
+            method name: 'debug', doc: '''
+                Enables debug mode, which outputs the full Docker commands that will be
+                run on the agent machine.
+            '''
         }
 
         if (enclosingCall('dockerCompose')) {
@@ -121,6 +135,19 @@ contributor([ctx, closureCtx]) {
                 Specify a Docker image to pull down to use as a layer cache for building the given service.
             '''
             method name: 'composeFile', params: [path: String], doc: 'Add a Docker Compose configuration file to use.'
+            method name: 'propagateEnvironment', doc: '''
+                Automatically propagate all pipeline environment variables into the container.
+            '''
+            method name: 'mountBuildkiteAgent', doc: '''
+                Automatically mount the `buildkite-agent` binary and associated environment 
+                variables from the host agent machine into the container.
+            '''
+            method name: 'expandVolumeVars', doc: '''
+                Activate the interpolation of variables in the elements of the volumes
+                configuration array. Environment variable interpolation rules apply here.
+                `$VARIABLE_NAME` is resolved at pipeline upload time, whereas `$$VARIABLE_NAME` is
+                at run time. All things being equal, you likely want `$$VARIABLE_NAME`.
+            '''
         }
     }
 


### PR DESCRIPTION
**What the change is:**
Adds extra configuration options to the `docker` and `docker-compose` steps to support using private Docker registries.
This PR exposes the following configuration options:
- `docker`
  - [mount-buildkite-agent](https://github.com/buildkite-plugins/docker-buildkite-plugin/#mount-buildkite-agent-optional-boolean)
  - [expand-volume-vars](https://github.com/buildkite-plugins/docker-buildkite-plugin/#expand-volume-vars-optional-boolean-run-only-unsafe)
  - [debug](https://github.com/buildkite-plugins/docker-buildkite-plugin/#debug-optional-boolean)
 
- `docker-compose`
  - [propagate-environment](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin#propagate-environment-optional-boolean)
  - [mount-buildkite-agent](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin#mount-buildkite-agent-optional-run-only-boolean)
  - [expand-volume-vars](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin#expand-volume-vars-optional-boolean-run-only-unsafe)

**Why the change is beneficial:**
Adds support for using private Docker repos to match the BuildKite documentation. Multiple vendors, including AWS [advice on dealing with Docker Hub rate limits](https://aws.amazon.com/blogs/containers/advice-for-customers-dealing-with-docker-hub-rate-limits-and-a-coming-soon-announcement/) by mirroring public images into your own private Docker registry. 
We use this plugin as a global template, and services that use that template can't currently use our private Docker mirror.

**Additional comments**
I updated the version of the `docker` and `docker-compose` plugins to match the latest available one.
If there's anything else needed, please just let me know!
