### PR TITLE
Add 'depends_on' to CommandStep

### DIFF
--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
@@ -208,6 +208,13 @@ class BuildkitePipeline implements ConfigurableEnvironment {
         }
 
         /**
+         * Make this step depend on the completion of another step
+         */
+        void dependsOn(String dependsOn) {
+            model.depends_on = dependsOn
+        }
+
+        /**
          * Add a Buildkite plugin to this step.
          *
          * @param name The plugin name or URL and version.


### PR DESCRIPTION
**What the change is**
Adding the depends_on attribute to CommandStep.

**Why the change is useful**
We have a requirement for certain steps to be dependent on each other, without relying on static waits. 

**Additional comments**
[Buildkite CommandStep documentation](https://buildkite.com/docs/pipelines/command-step)
If there's anything else needed, please just let me know!


