### PR TITLE
Add 'soft_fail' to CommandStep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ buildkite {
         commandStep {
             label ':boom: Soft fail step'
             command 'soft-fail.sh'
-            softFail()
+            softFail(1, 127)
         }
 
         waitStep()

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,12 @@ buildkite {
             }
         }
 
+        commandStep {
+            label ':boom: Soft fail step'
+            command 'soft-fail.sh'
+            softFail()
+        }
+
         waitStep()
 
         commandStep {

--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
@@ -661,6 +661,14 @@ class BuildkitePipeline implements ConfigurableEnvironment {
         void branches(String... branches) {
             model.branches = branches.join(' ')
         }
+
+        void softFail(boolean softFail = true) {
+            model.soft_fail = softFail
+        }
+
+        void softFail(int... exitStatuses) {
+            model.soft_fail = exitStatuses.toList()
+        }
     }
 
     /**

--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/BuildkitePipeline.groovy
@@ -667,7 +667,7 @@ class BuildkitePipeline implements ConfigurableEnvironment {
         }
 
         void softFail(int... exitStatuses) {
-            model.soft_fail = exitStatuses.toList()
+            model.soft_fail = exitStatuses.collect { exitStatus -> ['exit_status': exitStatus] }
         }
     }
 

--- a/buildSrc/src/main/groovy/com/widen/plugins/buildkite/idea/pipeline.gdsl
+++ b/buildSrc/src/main/groovy/com/widen/plugins/buildkite/idea/pipeline.gdsl
@@ -58,6 +58,10 @@ contributor([ctx, closureCtx]) {
         method name: 'automaticRetry', params: [body: Closure], doc: 'Retry this step automatically on failure.'
         method name: 'skip', doc: 'Skip this step.'
         method name: 'skip', params: [reason: String], doc: 'Skip this step with a given reason string.'
+        method name: 'softFail', params: [softFail: Boolean], doc: 'Soft fail this step.'
+        method name: 'softFail', params: [exitStatuses: 'java.lang.Integer[]'], doc: '''
+            Soft fail this step for the given exit statuses.
+        '''
         method name: 'timeout', params: [timeout: 'java.time.Duration'], doc: '''
             The amount of time a job created from this step is allowed to run. If the job does not finish within this
             limit, it will be automatically cancelled and the build will fail.


### PR DESCRIPTION
Adds the [`soft_fail`](https://buildkite.com/docs/pipelines/command-step#:~:text=%22My%20reason%22-,soft_fail,-Allow%20specified%20non) attribute to `CommandStep`, supporting both the `true` value or one or more `exit_status` values.
