### PR TITLE
fix(plugin): publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,14 @@ dependencies {
     compile localGroovy()
 }
 
+javadoc {
+    source 'buildSrc/src/main/java'
+}
+
+groovydoc {
+    source 'buildSrc/src/main/groovy'
+}
+
 jar {
     from "${rootProject.rootDir}/buildSrc/build/classes/groovy/main"
     from("${rootProject.rootDir}/buildSrc/src/main/groovy") {

--- a/buildSrc/src/main/java/com/widen/plugins/buildkite/JavadocStub.java
+++ b/buildSrc/src/main/java/com/widen/plugins/buildkite/JavadocStub.java
@@ -1,0 +1,8 @@
+package com.widen.plugins.buildkite;
+
+/**
+ * This class only serves as a placeholder to generate non-empty javadoc, which appears to be required for
+ * plugin publishing (and having multiple sources with the same hash causes an error within the plugin-publish plugin).
+ */
+public class JavadocStub {
+}


### PR DESCRIPTION
This is kind of a kludge, but it appears as though this will fix issues with the version of the publishing plugin that we're still making use of... Recent attempts at publishing fail with the following:

```
Execution failed for task ':publishPlugins'.
--
  | > Failed to post to server.
  | Server responded with:
  | Invalid publication, you have different artifacts with the same hash: (SOURCES and JAVADOC and GROOVYDOC). Support for this is only available with version 1.0+ of the plugin-publish plugin.
```

This led me down a bit of a rabbit hole, where I verified that we're currently assembling 4 source jars, and the three listed in the above failure do indeed have the same hash:

```sh
shasum --algorithm=256 *
1669545831339c6c7e4891b4e584f5f0b24c4c3d05ffc2dd288bef6ca9a92c98  buildkite-gradle-plugin-0.5.0-groovydoc.jar
1669545831339c6c7e4891b4e584f5f0b24c4c3d05ffc2dd288bef6ca9a92c98  buildkite-gradle-plugin-0.5.0-javadoc.jar
1669545831339c6c7e4891b4e584f5f0b24c4c3d05ffc2dd288bef6ca9a92c98  buildkite-gradle-plugin-0.5.0-sources.jar
56ec3f3f0fba5775b60c91a2605bcf57ae00237fb34ff34de5b69a446e9790cd  buildkite-gradle-plugin-0.5.0.jar
```

When inspecting the jar content, the three problem items only contained generic manifests, without any other unique data.

These changes are a very quick and dirty attempt at resolving the issue at hand, and by correctly establishing javadoc and groovydoc sources, and ensuring their content is actually generated, the source jars now have unique hash values.

It's likely that a more preferable path forward might involve upgrading `com.gradle.plugin-publish` to v1.1+, but that requires upgrading Gradle to v4.10.3+, which may or may not have pose other issues. All that being said, I can close this PR and try out this other attempt if that's more desired.